### PR TITLE
Fix macro names conflicts and compiler warnings

### DIFF
--- a/TPMCmd/tpm/include/GpMacros.h
+++ b/TPMCmd/tpm/include/GpMacros.h
@@ -161,8 +161,8 @@
 // These are defined for use when the size of the vector being checked is known
 // at compile time.
 #define TEST_BIT(bit, vector)   TestBit((bit), (BYTE *)&(vector), sizeof(vector))
-#define SET_BIT(bit, vector)    SetBit((bit), (BYTE *)&(vector), sizeof(vector))
-#define CLEAR_BIT(bit, vector) ClearBit((bit), (BYTE *)&(vector), sizeof(vector))
+#define MS_TPM_SET_BIT(bit, vector)    SetBit((bit), (BYTE *)&(vector), sizeof(vector))
+#define MS_TPM_CLEAR_BIT(bit, vector) ClearBit((bit), (BYTE *)&(vector), sizeof(vector))
 
 
 // The following definitions are used if they have not already been defined. The
@@ -181,7 +181,7 @@
 #define STD_RESPONSE_HEADER (sizeof(TPM_ST) + sizeof(UINT32) + sizeof(TPM_RC))
 
 #define JOIN(x,y) x##y
-#define CONCAT(x,y) JOIN(x, y)
+#define MS_TPM_CONCAT(x,y) JOIN(x, y)
 
 // If CONTEXT_INTEGRITY_HASH_ALG is defined, then the vendor is using the old style
 // table. Otherwise, pick the "strongest" implemented hash algorithm as the context
@@ -198,11 +198,11 @@
 #   elif defined ALG_SHA1 && ALG_SHA1 == YES
 #       define CONTEXT_HASH_ALGORITHM  SHA1  
 #   endif
-#   define CONTEXT_INTEGRITY_HASH_ALG  CONCAT(TPM_ALG_, CONTEXT_HASH_ALGORITHM)
+#   define CONTEXT_INTEGRITY_HASH_ALG  MS_TPM_CONCAT(TPM_ALG_, CONTEXT_HASH_ALGORITHM)
 #endif
 
 #ifndef CONTEXT_INTEGRITY_HASH_SIZE
-#define CONTEXT_INTEGRITY_HASH_SIZE CONCAT(CONTEXT_HASH_ALGORITHM, _DIGEST_SIZE)
+#define CONTEXT_INTEGRITY_HASH_SIZE MS_TPM_CONCAT(CONTEXT_HASH_ALGORITHM, _DIGEST_SIZE)
 #endif
 
 #ifdef TPM_ALG_RSA
@@ -271,9 +271,9 @@
 
 // If CONTEXT_ENCRYP_ALG is defined, then the vendor is using the old style table
 #ifndef CONTEXT_ENCRYPT_ALG
-#define CONTEXT_ENCRYPT_ALG             CONCAT(TPM_ALG_, CONTEXT_ENCRYPT_ALGORITHM)
+#define CONTEXT_ENCRYPT_ALG             MS_TPM_CONCAT(TPM_ALG_, CONTEXT_ENCRYPT_ALGORITHM)
 #define CONTEXT_ENCRYPT_KEY_BITS                            \
-                CONCAT(CONCAT(MAX_, CONTEXT_ENCRYPT_ALGORITHM), _KEY_BITS)
+                MS_TPM_CONCAT(MS_TPM_CONCAT(MAX_, CONTEXT_ENCRYPT_ALGORITHM), _KEY_BITS)
 #define CONTEXT_ENCRYPT_KEY_BYTES       ((CONTEXT_ENCRYPT_KEY_BITS+7)/8)
 #endif
 

--- a/TPMCmd/tpm/src/crypt/AlgorithmTests.c
+++ b/TPMCmd/tpm/src/crypt/AlgorithmTests.c
@@ -59,13 +59,13 @@
                 TestHash(DEFAULT_TEST_HASH, vector);
 
 // Make sure that the algorithm has been tested
-#define CLEAR_BOTH(alg)     {   CLEAR_BIT(alg, *toTest);                        \
+#define CLEAR_BOTH(alg)     {   MS_TPM_CLEAR_BIT(alg, *toTest);                        \
                                 if(toTest != &g_toTest)                         \
-                                    CLEAR_BIT(alg, g_toTest); }
+                                    MS_TPM_CLEAR_BIT(alg, g_toTest); }
 
-#define SET_BOTH(alg)     {   SET_BIT(alg, *toTest);                            \
+#define SET_BOTH(alg)     {   MS_TPM_SET_BIT(alg, *toTest);                            \
                                 if(toTest != &g_toTest)                         \
-                                    SET_BIT(alg, g_toTest); }
+                                    MS_TPM_SET_BIT(alg, g_toTest); }
 
 #define TEST_BOTH(alg)       ((toTest != &g_toTest)                              \
                             ? TEST_BIT(alg, *toTest) || TEST_BIT(alg, g_toTest)  \
@@ -813,7 +813,7 @@ TestAlgorithm(
         // silently CLEAR it. Decided to just clear.
         if(!TEST_BIT(alg, g_implementedAlgorithms))
         {
-            CLEAR_BIT(alg, *toTest);
+            MS_TPM_CLEAR_BIT(alg, *toTest);
             continue;
         }
         // Process whatever is left.
@@ -862,7 +862,7 @@ TestAlgorithm(
                     // to test one of the modes for the symmetric algorithms. If
                     // initializing for a SelfTest(FULL_TEST), allow all the modes.
                     if(toTest == &g_toTest)
-                        CLEAR_BIT(alg, *toTest);
+                        MS_TPM_CLEAR_BIT(alg, *toTest);
                 break;
 #ifndef TPM_ALG_HMAC
 #   error   HMAC is required in all TPM implementations
@@ -946,7 +946,7 @@ TestAlgorithm(
                 break;
 #endif // TPM_ALG_ECC
             default:
-                CLEAR_BIT(alg, *toTest);
+                MS_TPM_CLEAR_BIT(alg, *toTest);
                 break;
         }
         if(result != TPM_RC_SUCCESS)

--- a/TPMCmd/tpm/src/crypt/CryptEccMain.c
+++ b/TPMCmd/tpm/src/crypt/CryptEccMain.c
@@ -366,7 +366,7 @@ CryptCommit(
 {
     UINT16      oldCount = (UINT16)gr.commitCounter;
     gr.commitCounter++;
-    SET_BIT(oldCount & COMMIT_INDEX_MASK, gr.commitArray);
+    MS_TPM_SET_BIT(oldCount & COMMIT_INDEX_MASK, gr.commitArray);
     return oldCount;
 }
 

--- a/TPMCmd/tpm/src/crypt/CryptSelfTest.c
+++ b/TPMCmd/tpm/src/crypt/CryptSelfTest.c
@@ -141,7 +141,7 @@ CryptIncrementalSelfTest(
             // make sure that the algorithm value is not out of range
             if((alg > TPM_ALG_LAST) || !TEST_BIT(alg, g_implementedAlgorithms))
                 return TPM_RC_VALUE;
-            SET_BIT(alg, toTestVector);
+            MS_TPM_SET_BIT(alg, toTestVector);
         }
         // Run the test
         if(CryptRunSelfTests(&toTestVector) == TPM_RC_CANCELED)
@@ -213,9 +213,9 @@ CryptTestAlgorithm(
     // algorithms have tests, 'toTest' can be cleared.
     if(alg != TPM_ALG_ERROR)
     {
-        CLEAR_BIT(alg, g_toTest);
+        MS_TPM_CLEAR_BIT(alg, g_toTest);
         if(toTest != NULL)
-            CLEAR_BIT(alg, *toTest);
+            MS_TPM_CLEAR_BIT(alg, *toTest);
     }
     result = TPM_RC_SUCCESS;
 #endif

--- a/TPMCmd/tpm/src/subsystem/CommandAudit.c
+++ b/TPMCmd/tpm/src/subsystem/CommandAudit.c
@@ -117,7 +117,7 @@ CommandAuditSet(
             if(!TEST_BIT(commandIndex, gp.auditCommands))
             {
                 // Set bit
-                SET_BIT(commandIndex, gp.auditCommands);
+                MS_TPM_SET_BIT(commandIndex, gp.auditCommands);
                 return TRUE;
             }
         }
@@ -154,7 +154,7 @@ CommandAuditClear(
             if(TEST_BIT(commandIndex, gp.auditCommands))
             {
                 // Clear bit
-                CLEAR_BIT(commandIndex, gp.auditCommands);
+                MS_TPM_CLEAR_BIT(commandIndex, gp.auditCommands);
                 return TRUE;
             }
         }

--- a/TPMCmd/tpm/src/subsystem/PP.c
+++ b/TPMCmd/tpm/src/subsystem/PP.c
@@ -66,7 +66,7 @@ PhysicalPresencePreInstall_Init(
     {
         if(s_commandAttributes[commandIndex] & IS_IMPLEMENTED
            &&  s_commandAttributes[commandIndex] & PP_REQUIRED)
-            SET_BIT(commandIndex, gp.ppList);
+            MS_TPM_SET_BIT(commandIndex, gp.ppList);
     }
     // Write PP list to NV
     NV_SYNC_PERSISTENT(ppList);
@@ -89,7 +89,7 @@ PhysicalPresenceCommandSet(
 
     // only set the bit if this is a command for which PP is allowed
     if(s_commandAttributes[commandIndex] & PP_COMMAND)
-        SET_BIT(commandIndex, gp.ppList);
+        MS_TPM_SET_BIT(commandIndex, gp.ppList);
     return;
 }
 
@@ -109,7 +109,7 @@ PhysicalPresenceCommandClear(
 
     // Only clear the bit if the command does not require PP
     if((s_commandAttributes[commandIndex] & PP_REQUIRED) == 0)
-        CLEAR_BIT(commandIndex, gp.ppList);
+        MS_TPM_CLEAR_BIT(commandIndex, gp.ppList);
 
     return;
 }

--- a/TPMCmd/tpm/src/support/AlgorithmCap.c
+++ b/TPMCmd/tpm/src/support/AlgorithmCap.c
@@ -227,6 +227,6 @@ AlgorithmGetImplementedVector(
     for(index = (sizeof(s_algorithms) / sizeof(s_algorithms[0])) - 1;
     index >= 0;
         index--)
-        SET_BIT(s_algorithms[index].algID, *implemented);
+        MS_TPM_SET_BIT(s_algorithms[index].algID, *implemented);
     return;
 }

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -2,6 +2,7 @@ if (CONFIG_TPM2_MS_REF)
     add_subdirectory(${ZEPHYR_CURRENT_MODULE_DIR}/zephyr/platform)
 
     zephyr_library_named(ms-tpm-20-ref)
+    zephyr_library_compile_options(-Wno-expansion-to-defined -Wno-missing-braces)
     target_include_directories(
         ms-tpm-20-ref PUBLIC ${ZEPHYR_CURRENT_MODULE_DIR}/TPMCmd/tpm/include ${ZEPHYR_CURRENT_MODULE_DIR}/TPMCmd/tpm/include/prototypes
     )


### PR DESCRIPTION
This PR fixes massive amount of warnings and other problems caused by macro names conflicts between Zephyr and ms-tpm. Some other warnings also have been fixed.